### PR TITLE
Update zm_prison.gsc

### DIFF
--- a/zm_prison_patch/maps/mp/zm_prison.gsc
+++ b/zm_prison_patch/maps/mp/zm_prison.gsc
@@ -1108,6 +1108,7 @@ alcatraz_afterlife_doors() //checked changed to match cerberus output
 						{
 							array_delete( getentarray( m_shockbox.script_string, "script_noteworthy" ) );
 						}
+						self maps/mp/zombies/_zm_blockers::door_opened( 0 ); //you have to buy doors after powering them if you don't do this
 						attacker notify( "player_opened_afterlife_door" );
 						break;
 					}


### PR DESCRIPTION
added a line to call ```door_opened( 0 )``` after powering an afterlife shock box door.  if this is not done, you have to spend points after powering the door, which doesn't happen normally.