### PR TITLE
add .gitattributes to allow gsc language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gsc linguist-detectable


### PR DESCRIPTION
allows Github linguist to detect .gsc files as the language "GSC", and adds syntax highlighting. 
added to linguist by this commit github/linguist#5634